### PR TITLE
fix a bug that would cause exception if Redux DevTools is absent

### DIFF
--- a/src/createReduxStore.js
+++ b/src/createReduxStore.js
@@ -22,7 +22,7 @@ function createReduxStore(options) {
       combinedReducers,
       compose(
         applyMiddleware(...middlewares),
-        window.devToolsExtension ? window.devToolsExtension() : undefined,
+        window.devToolsExtension ? window.devToolsExtension() : f => f,
       )
     );
 


### PR DESCRIPTION
If we pass undefined as an argument to compose, that argument will still be invoked as a function and cause an exception. Therefore we need to pass identity function instead.
